### PR TITLE
Add support for Pint (automata network) format

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For now it supports the following formats (< and > denote import/export capabili
   *  > [GINML](http://doc.ginsim.org/format-ginml.html)
   *  > [GNA](http://ibis.inrialpes.fr/article122.html)
   *  > Petri net (INA, PNML, APNN)
+  *  > [Pint](http://loicpauleve.name/pint)
   * <> [Truth table](http://doc.ginsim.org/format-truthtable.html)
 
 The integration of a filter only requires a simple format declaration class.

--- a/src/main/java/org/colomoto/logicalmodel/io/pint/PintExport.java
+++ b/src/main/java/org/colomoto/logicalmodel/io/pint/PintExport.java
@@ -1,0 +1,113 @@
+package org.colomoto.logicalmodel.io.pint;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.List;
+
+import org.colomoto.logicalmodel.LogicalModel;
+import org.colomoto.logicalmodel.NodeInfo;
+import org.colomoto.mddlib.MDDManager;
+import org.colomoto.mddlib.MDDVariable;
+import org.colomoto.mddlib.PathSearcher;
+
+/**
+ * Export logical model into the Pint format.
+ *
+ * @author Loic Pauleve
+ */
+public class PintExport {
+
+	/**
+	 * Export a logical model into automata network transitions
+	 *
+	 * @param model
+	 * @param out
+	 * @throws IOException
+	 */
+	public void export(LogicalModel model, OutputStream out) throws IOException {
+
+		final List<NodeInfo> nodes = model.getNodeOrder();
+
+		Writer writer = new OutputStreamWriter(out);
+
+		writer.write("(* This model has been automatically generated using colomoto/logicalmodels\n");
+		writer.write(" * You may want to optimize this model for pint using the following command:\n");
+		writer.write("       pint-export --simplify -i model.an -o model.an\n");
+		writer.write(" * where model.an is this file.\n *)\n\n");
+
+		/*
+		 * Automata declaration
+		 */
+		int i;
+		for (NodeInfo ni: nodes) {
+			writer.write('"'+ni.getNodeID()+"\" [0");
+			for (i = 1; i <= ni.getMax(); ++i) {
+				writer.write(", "+i);
+			}
+			writer.write("]\n");
+		}
+		writer.write("\n");
+
+		/*
+		 * Transitions
+		 */
+		MDDManager ddmanager = model.getMDDManager();
+		MDDVariable[] variables = ddmanager.getAllVariables();
+		PathSearcher searcher = new PathSearcher(ddmanager);
+
+		int[] functions = model.getLogicalFunctions();
+		for (int idx=0 ; idx<functions.length ; idx++) {
+			MDDVariable var = variables[idx];
+			NodeInfo ni = nodes.get(idx);
+
+			// write a normalised logical function
+			int[] path = searcher.setNode(functions[idx]);
+			for (int leaf: searcher) {
+				int selfcond = -1;
+
+				boolean first = true;
+				String cond = "";
+				for (i=0 ; i<path.length ; i++) {
+					int cst = path[i];
+					if (cst < 0) {
+						continue;
+					}
+					if (i == idx) {
+						selfcond = cst;
+						continue;
+					}
+					if (!first) {
+						cond += " and ";
+					}
+					first = false;
+					cond += '"'+nodes.get(i).toString()+"\"="+cst;
+				}
+
+				int omin = 0;
+				int omax = ni.getMax();
+				if (selfcond >= 0) {
+					omin = omax = selfcond;
+				}
+				for (i = omin; i <= omax; ++i) {
+					if (leaf == i) {
+						continue;
+					}
+					int j = i < leaf ? i+1 : i-1;
+					writer.write('"'+ni.toString()+"\" " + i + " -> " + j);
+					if (!first) {
+						writer.write(" when " + cond);
+					}
+					writer.write("\n");
+				}
+			}
+			writer.write("\n");
+		}
+
+		/* TODO: initial state? */
+
+		writer.close();
+	}
+}
+

--- a/src/main/java/org/colomoto/logicalmodel/io/pint/PintFormat.java
+++ b/src/main/java/org/colomoto/logicalmodel/io/pint/PintFormat.java
@@ -1,0 +1,32 @@
+package org.colomoto.logicalmodel.io.pint;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.colomoto.logicalmodel.LogicalModel;
+import org.colomoto.logicalmodel.io.AbstractFormat;
+import org.colomoto.logicalmodel.io.LogicalModelFormat;
+import org.mangosdk.spi.ProviderFor;
+
+@ProviderFor(LogicalModelFormat.class)
+public class PintFormat extends AbstractFormat {
+
+	public PintFormat() { super("an", "Pint format", true); }
+
+	/*
+	@Override
+	public LogicalModel importFile(File f) throws IOException {
+		PintImport importer = new PintImport();
+		importer.parse(f);
+		return importer.getModel();
+	}
+	*/
+
+	@Override
+	public void export(LogicalModel model, OutputStream out) throws IOException {
+		PintExport exporter = new PintExport();
+		exporter.export(model, out);
+	}
+}
+

--- a/src/main/java/org/colomoto/logicalmodel/io/pint/package-info.java
+++ b/src/main/java/org/colomoto/logicalmodel/io/pint/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The format used by Pint - http://loicpauleve.name/pint
+ */
+package org.colomoto.logicalmodel.io.pint;


### PR DESCRIPTION
Hi,
Here is a first attempt for exporting in pint format (.an).
Basically, for each node an automaton is created with the appropriate number of local states.
Then the local transitions are derived from each path in the MDD structure.
In Pint format a local transition is specified like this:
`a i -> j when b=k and c=l`
Let us note "a" the current node, L the leaf of the path, and COND the conditions on the nodes different than a (separated with " and "):
- if the path depends on the value of "a" (a=i), a single transition is added:
    `a i -> j when COND`
- otherwise, for each possible value i of "a" that is different from L, we add
     `a i -> j when COND`

where j=i+1 if L > i; j=i-1 otherwise.
I hope I understood the API correctly (in particular path[i] < 0 iff the i-th variable is not tested)